### PR TITLE
Type of subprotocol is str, not List[str]

### DIFF
--- a/starlette/websockets.py
+++ b/starlette/websockets.py
@@ -107,7 +107,7 @@ class WebSocket(HTTPConnection):
         else:
             raise RuntimeError('Cannot call "send" once a close message has been sent.')
 
-    async def accept(self, subprotocol: typing.List[str] = None) -> None:
+    async def accept(self, subprotocol: str = None) -> None:
         if self.client_state == WebSocketState.CONNECTING:
             # If we haven't yet seen the 'connect' message, then wait for it first.
             await self.receive()


### PR DESCRIPTION
According to the ASGI spec:
- `type`: `websocket.accept`
- `subprotocol`: The subprotocol the server wishes to accept, as a **unicode string**. Optional, defaults to `None`.